### PR TITLE
add clientside routing & redux store persitence

### DIFF
--- a/pages/anotherpage/+Page.jsx
+++ b/pages/anotherpage/+Page.jsx
@@ -1,0 +1,23 @@
+export default Page
+
+import React from 'react'
+import { navigate } from 'vike/client/router'
+import { useSelector, useDispatch } from 'react-redux'
+
+function Page() {
+  const count = useSelector((state) => state.value)
+  const dispatch = useDispatch()
+
+  const increment = () => dispatch({ type: 'counter/incremented' })
+  const decrement = () => dispatch({ type: 'counter/decremented' })
+  const navigateToIndexPage = () => navigate('/')
+
+  return (
+    <>
+      <h1>Redux-Controlled Counter</h1>
+      Count: {count}. <button onClick={increment}>++</button> <button onClick={decrement}>--</button>
+      <h1>Redux Store persists on clienside routing</h1>
+      <button onClick={navigateToIndexPage}>Go to Index Page</button>
+    </>
+  )
+}

--- a/pages/index/+Page.jsx
+++ b/pages/index/+Page.jsx
@@ -1,6 +1,7 @@
 export default Page
 
 import React from 'react'
+import { navigate } from 'vike/client/router'
 import { useSelector, useDispatch } from 'react-redux'
 
 function Page() {
@@ -9,11 +10,14 @@ function Page() {
 
   const increment = () => dispatch({ type: 'counter/incremented' })
   const decrement = () => dispatch({ type: 'counter/decremented' })
+  const navigateToAnotherPage = () => navigate('/anotherpage')
 
   return (
     <>
       <h1>Redux-Controlled Counter</h1>
       Count: {count}. <button onClick={increment}>++</button> <button onClick={decrement}>--</button>
+      <h1>Redux Store persists on clienside routing</h1>
+      <button onClick={navigateToAnotherPage}>Go to another page</button>
     </>
   )
 }

--- a/renderer/+config.h.js
+++ b/renderer/+config.h.js
@@ -1,4 +1,6 @@
 // https://vike.dev/passToClient
 export default {
-  passToClient: ['PRELOADED_STATE']
+  passToClient: ['PRELOADED_STATE'],
+  hydrationCanBeAborted: true,
+  clientRouting: true
 }

--- a/renderer/+onRenderClient.jsx
+++ b/renderer/+onRenderClient.jsx
@@ -5,19 +5,19 @@ import React from 'react'
 import { hydrateRoot, createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { getStore } from './store'
-import config from './+config.h'
 
 // this example has client-side routing enabled ( see `+config.h.js` )
 // for SSR only you can disable both `clientRouting` and `hydrationCanBeAborted`
 
 let root
+// store is initialized only once on the client, so it can persist between client-side navigations
 let store = null
 async function onRenderClient(pageContext) {
   const { Page } = pageContext
   
   // If we use Client Routing, then we should initialize the store only once
   // (See https://vike.dev/server-routing-vs-client-routing for more information about Client Routing and Server Routing.)
-  if(!config.clientRouting || !store) {
+  if(!store) {
     store = getStore(pageContext.PRELOADED_STATE)
   }
   

--- a/renderer/+onRenderClient.jsx
+++ b/renderer/+onRenderClient.jsx
@@ -2,19 +2,38 @@
 export default onRenderClient
 
 import React from 'react'
-import { hydrateRoot } from 'react-dom/client'
+import { hydrateRoot, createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { getStore } from './store'
+import config from './+config.h'
 
+// this example has client-side routing enabled ( see `+config.h.js` )
+// for SSR only you can disable both `clientRouting` and `hydrationCanBeAborted`
+
+let root
+let store = null
 async function onRenderClient(pageContext) {
   const { Page } = pageContext
-  // We initilaize the store on every render because we use Server Routing. If we use Client Routing, then we should initialize the store only once instead.
+  
+  // If we use Client Routing, then we should initialize the store only once
   // (See https://vike.dev/server-routing-vs-client-routing for more information about Client Routing and Server Routing.)
-  const store = getStore(pageContext.PRELOADED_STATE)
-  hydrateRoot(
-    document.getElementById('react-root'),
+  if(!config.clientRouting || !store) {
+    store = getStore(pageContext.PRELOADED_STATE)
+  }
+  
+  const page = (
     <Provider store={store}>
       <Page />
     </Provider>
   )
+
+  const container = document.getElementById('react-root')
+  if (pageContext.isHydration) {
+    root = hydrateRoot(container, page)
+  } else {
+    if (!root) {
+      root = createRoot(container)
+    }
+    root.render(page)
+  }
 }


### PR DESCRIPTION
This adds:

- enables `clientRouting`
- enables `hydrationCanBeAborted`
- updates rendering stategy of `onRenderClient` for client side routing according to [this example](https://github.com/vikejs/vike/blob/main/examples/react-full-v1/renderer/+onRenderClient.tsx)
- moves redux store into a global variable and only initalize it if the store isn't initalized
- add `/anotherpage` to prove store persistence on client routing
- add buttons for clientside navigation between index and `/anotherpage`

Thoughts:

- can store persistence break when navigated page has SSR features?

Let know on comments & changes :)
